### PR TITLE
Fix main

### DIFF
--- a/iterator/include/iterator.hpp
+++ b/iterator/include/iterator.hpp
@@ -31,7 +31,7 @@ public:
         size_t rest = (n > 0) ? width_ - index_ % stride_  - 1: index_ % stride_;
         size_t stride_count = 0;
 
-        if (abs(n) > rest)
+        if (abs(n) > (int)rest)
         {
             stride_count = ceil((double)(abs(n) - rest) / width_);
         }

--- a/parser/include/csv.hpp
+++ b/parser/include/csv.hpp
@@ -72,7 +72,7 @@ namespace literals
         //{ declare ``_csv`` literal
         types::csv::csv operator "" _csv(const char* s, size_t size)
         {
-            return parser::load_from_string<types::csv::csv>(s, parser::csv::csv);
+            return parser::load_from_string<types::csv::csv>(std::string(s, size), parser::csv::csv);
         }
         //}
     }

--- a/parser/include/quoted_string.hpp
+++ b/parser/include/quoted_string.hpp
@@ -14,7 +14,7 @@ namespace parser
     namespace x3 = boost::spirit::x3;
 
     //{ should be only one line
-    const auto quoted_string = x3::lexeme['"' >> *('\\' >> x3::char_ | ~x3::char_('"')) >> '"'];;
+    const auto quoted_string = x3::lexeme['"' >> *('\\' >> x3::char_ | ~x3::char_('"')) >> '"'];
     //}
 }
 

--- a/type_map/include/type_map.hpp
+++ b/type_map/include/type_map.hpp
@@ -53,7 +53,7 @@ public:
 namespace std
 {
     template<typename T, class TypeMap>
-    ?? get(??TypeMap?? tm)
+    auto& get(TypeMap& tm)
     {
         return tm.template as<T>();
     }


### PR DESCRIPTION
Небольшие правки, чтобы проект собирался через главный CMakeLists.txt

<details>
<summary>
<i>Test results</i>
</summary>
<code>
Test project /home/ybogomolov/cxx-tasks/build
      Start  1: tests_iomanip:iomanip::simple
 1/38 Test  #1: tests_iomanip:iomanip::simple ..................   Passed    0.00 sec
      Start  2: tests_iomanip:iomanip::one_operand
 2/38 Test  #2: tests_iomanip:iomanip::one_operand .............   Passed    0.00 sec
      Start  3: tests_iomanip:iomanip::two_operands
 3/38 Test  #3: tests_iomanip:iomanip::two_operands ............   Passed    0.00 sec
      Start  4: tests_iterator:iterator::operations
 4/38 Test  #4: tests_iterator:iterator::operations ............   Passed    0.00 sec
      Start  5: tests_iterator:iterator::write
 5/38 Test  #5: tests_iterator:iterator::write .................   Passed    0.00 sec
      Start  6: tests_iterator:iterator::copy_from_vector
 6/38 Test  #6: tests_iterator:iterator::copy_from_vector ......   Passed    0.00 sec
      Start  7: tests_iterator:iterator::copy_to_vector
 7/38 Test  #7: tests_iterator:iterator::copy_to_vector ........   Passed    0.00 sec
      Start  8: tests_parser:csv::string
 8/38 Test  #8: tests_parser:csv::string .......................   Passed    0.00 sec
      Start  9: tests_parser:csv::cell
 9/38 Test  #9: tests_parser:csv::cell .........................   Passed    0.00 sec
      Start 10: tests_parser:csv::row
10/38 Test #10: tests_parser:csv::row ..........................   Passed    0.00 sec
      Start 11: tests_parser:csv::csv
11/38 Test #11: tests_parser:csv::csv ..........................   Passed    0.00 sec
      Start 12: tests_parser:csv::operator_csv
12/38 Test #12: tests_parser:csv::operator_csv .................   Passed    0.00 sec
      Start 13: tests_parser:json::number
13/38 Test #13: tests_parser:json::number ......................   Passed    0.00 sec
      Start 14: tests_parser:json::nullable
14/38 Test #14: tests_parser:json::nullable ....................   Passed    0.00 sec
      Start 15: tests_parser:json::array
15/38 Test #15: tests_parser:json::array .......................   Passed    0.00 sec
      Start 16: tests_parser:json::object
16/38 Test #16: tests_parser:json::object ......................   Passed    0.00 sec
      Start 17: tests_parser:json::json
17/38 Test #17: tests_parser:json::json ........................   Passed    0.00 sec
      Start 18: tests_parser:json::operator_json
18/38 Test #18: tests_parser:json::operator_json ...............   Passed    0.00 sec
      Start 19: tests_parser:quoted_string::spaces
19/38 Test #19: tests_parser:quoted_string::spaces .............   Passed    0.00 sec
      Start 20: tests_parser:quoted_string::comma
20/38 Test #20: tests_parser:quoted_string::comma ..............   Passed    0.00 sec
      Start 21: tests_parser:quoted_string::quote
21/38 Test #21: tests_parser:quoted_string::quote ..............   Passed    0.00 sec
      Start 22: tests_parser:quoted_string::newline
22/38 Test #22: tests_parser:quoted_string::newline ............   Passed    0.00 sec
      Start 23: tests_parser:quoted_string::failure
23/38 Test #23: tests_parser:quoted_string::failure ............   Passed    0.00 sec
      Start 24: tests_parser:variant_decorator::constructors
24/38 Test #24: tests_parser:variant_decorator::constructors ...   Passed    0.00 sec
      Start 25: tests_parser:variant_decorator::as
25/38 Test #25: tests_parser:variant_decorator::as .............   Passed    0.00 sec
      Start 26: tests_parser:variant_decorator::const
26/38 Test #26: tests_parser:variant_decorator::const ..........   Passed    0.00 sec
      Start 27: tests_proxy:proxy::access
27/38 Test #27: tests_proxy:proxy::access ......................   Passed    0.00 sec
      Start 28: tests_proxy:proxy::threadsafe
28/38 Test #28: tests_proxy:proxy::threadsafe ..................   Passed    1.01 sec
      Start 29: tests_proxy:proxy::primitive
29/38 Test #29: tests_proxy:proxy::primitive ...................   Passed    0.00 sec
      Start 30: tests_type_map:type_map::int
30/38 Test #30: tests_type_map:type_map::int ...................   Passed    0.00 sec
      Start 31: tests_type_map:type_map::enum
31/38 Test #31: tests_type_map:type_map::enum ..................   Passed    0.00 sec
      Start 32: tests_type_map:type_map::write
32/38 Test #32: tests_type_map:type_map::write .................   Passed    0.00 sec
      Start 33: tests_variant:variant::number
33/38 Test #33: tests_variant:variant::number ..................   Passed    0.00 sec
      Start 34: tests_variant:variant::array
34/38 Test #34: tests_variant:variant::array ...................   Passed    0.00 sec
      Start 35: tests_variant:variant::recursive_array
35/38 Test #35: tests_variant:variant::recursive_array .........   Passed    0.00 sec
      Start 36: tests_variant:variant::recursive_array2
36/38 Test #36: tests_variant:variant::recursive_array2 ........   Passed    0.00 sec
      Start 37: tests_variant:variant::variant_decorator
37/38 Test #37: tests_variant:variant::variant_decorator .......   Passed    0.00 sec
      Start 38: tests_variant:variant::recursive_map
38/38 Test #38: tests_variant:variant::recursive_map ...........   Passed    0.00 sec

100% tests passed, 0 tests failed out of 38

Label Time Summary:
tests_iomanip     =   0.01 sec*proc (3 tests)
tests_iterator    =   0.01 sec*proc (4 tests)
tests_parser      =   0.04 sec*proc (19 tests)
tests_proxy       =   1.01 sec*proc (3 tests)
tests_type_map    =   0.01 sec*proc (3 tests)
tests_variant     =   0.01 sec*proc (6 tests)

Total Test time (real) =   1.15 sec
</code>
</details>